### PR TITLE
Add README with usage docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Node Proxy
+
+This project is a simple proxy server built with Express and `http-proxy-middleware`. It forwards all incoming requests to [JSONPlaceholder](https://jsonplaceholder.typicode.com) and listens on **port 8888** by default.
+
+## Installation
+
+```bash
+npm install
+```
+
+## Development
+
+Start the proxy in development mode:
+
+```bash
+npm run dev
+```
+
+## Build
+
+Compile the TypeScript source:
+
+```bash
+npm run build
+```
+
+## Start
+
+Run the compiled server:
+
+```bash
+npm start
+```
+
+The proxy will launch on `http://localhost:8888` and forward API calls to `https://jsonplaceholder.typicode.com`.


### PR DESCRIPTION
## Summary
- add project README describing setup and default proxy target
- create `.gitignore` to exclude node_modules

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f44dedde08333a2031300aab75e0d